### PR TITLE
Update Lexus GX 470 generations: Added Wikipedia reference and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Model make
+# Lexus GX 470
+
+This repository contains signal set configurations for the Lexus GX 470, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Lexus GX 470.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
 

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Lexus_GX"
+
 generations:
   - name: "First Generation (J120)"
     start_year: 2003


### PR DESCRIPTION
- Added reference to Lexus GX Wikipedia article
- Updated README.md with standard template
- Verified generation data matches Wikipedia (2003-2009, J120 platform)
